### PR TITLE
fix issues to support sklearn=1.2.2

### DIFF
--- a/deconfounder/causal_tree.py
+++ b/deconfounder/causal_tree.py
@@ -1,20 +1,19 @@
 from sklearn.tree import DecisionTreeRegressor
-from .mse_causal import CausalCriterion
+from mse_causal import CausalCriterion
 import pandas as pd
 import numpy as np
 
 class CausalTree(DecisionTreeRegressor):
 
-    def fit(self, X, y, sample_weight=None, check_input=True, X_idx_sorted=None):
+    def fit(self, X, y, sample_weight=None, check_input=True):
         """
         Replaces the string stored in criterion by an instance of a class.
         """
         self.criterion = CausalCriterion(1, X.shape[0])
-        treated = X.treated.values.astype(int)
+        treated = X.treated.values.astype('int32')
         self.criterion.set_treated(treated)
         X_base = X.loc[:, X.columns != 'treated']
-        DecisionTreeRegressor.fit(self, X_base, y, sample_weight=sample_weight, check_input=check_input,
-                                  X_idx_sorted=X_idx_sorted)
+        DecisionTreeRegressor.fit(self, X_base, y, sample_weight=sample_weight, check_input=check_input)
         return self
 
     def predict(self, X, check_input=True):

--- a/deconfounder/mse_causal.pyx
+++ b/deconfounder/mse_causal.pyx
@@ -1,5 +1,6 @@
 from sklearn.tree._criterion cimport Criterion
 from sklearn.tree._criterion cimport SIZE_t
+import numpy as np
 
 from libc.stdlib cimport calloc
 from libc.stdlib cimport free
@@ -34,7 +35,7 @@ cdef class CausalCriterion(Criterion):
         cdef int is_treated
 
         # Default values
-        self.sample_weight = NULL
+        # self.sample_weight = NULL
 
         self.samples = NULL
         self.start = 0
@@ -60,8 +61,16 @@ cdef class CausalCriterion(Criterion):
 
     def __reduce__(self):
         return (type(self), (self.n_outputs, self.n_samples), self.__getstate__())
+    
+    def __getstate__(self):
+        d = {}
+        d['treated'] = np.asarray(self.treated)
+        return d
 
-    cdef int init(self, const DOUBLE_t[:, ::1] y, DOUBLE_t* sample_weight,
+    def __setstate__(self, d):
+        self.treated = np.asarray(d['treated'])
+
+    cdef int init(self, const DOUBLE_t[:, ::1] y, const DOUBLE_t[:] sample_weight,
                   double weighted_n_samples, SIZE_t* samples, SIZE_t start,
                   SIZE_t end) nogil except -1:
         """Initialize the criterion at node samples[start:end] and
@@ -84,19 +93,19 @@ cdef class CausalCriterion(Criterion):
         cdef DOUBLE_t w_y_ik
         cdef DOUBLE_t w = 1.0
         cdef int is_treated
-
+       
         for is_treated in range(2):
             self.sq_sum_total_arr[is_treated] = 0.0
             self.sum_total_arr[is_treated] = 0.0
             self.weighted_n_node_arr[is_treated] = 0.0
-
+        
         for p in range(start, end):
             i = samples[p]
             is_treated = self.treated[i]
-
-            if sample_weight != NULL:
+            
+            if sample_weight is not None:
                 w = sample_weight[i]
-
+            
             for k in range(self.n_outputs):
                 y_ik = self.y[i, k]
                 w_y_ik = w * y_ik
@@ -105,11 +114,11 @@ cdef class CausalCriterion(Criterion):
 
                 if self.largest_y < fabs(y_ik):
                     self.largest_y = fabs(y_ik)
-
+            
             self.weighted_n_node_arr[is_treated] += w
-
+        
         self.weighted_n_node_samples = self.weighted_n_node_arr[U_IX] + self.weighted_n_node_arr[T_IX]
-
+        
         # Reset to pos=start
         self.reset()
         self.weighted_n_left = self.weighted_n_left_arr[U_IX] + self.weighted_n_right_arr[T_IX]
@@ -158,7 +167,7 @@ cdef class CausalCriterion(Criterion):
         cdef double* sq_sum_right = self.sq_sum_right_arr
         cdef double* sq_sum_total = self.sq_sum_total_arr
 
-        cdef double* sample_weight = self.sample_weight
+        cdef const DOUBLE_t[:] sample_weight = self.sample_weight
         cdef SIZE_t* samples = self.samples
 
         cdef SIZE_t pos = self.pos
@@ -184,7 +193,7 @@ cdef class CausalCriterion(Criterion):
                 i = samples[p]
                 is_treated = self.treated[i]
 
-                if sample_weight != NULL:
+                if sample_weight is not None:
                     w = sample_weight[i]
 
                 for k in range(self.n_outputs):
@@ -201,7 +210,7 @@ cdef class CausalCriterion(Criterion):
                 i = samples[p]
                 is_treated = self.treated[i]
 
-                if sample_weight != NULL:
+                if sample_weight is not None:
                     w = sample_weight[i]
 
                 for k in range(self.n_outputs):


### PR DESCRIPTION
Hi Carlos,

I created a new branch named "hyf" and pushed the modified files to this. Besides, I forgot to mention the modifications of "causal_tree.py" during meeting, including: 1)  the input parameter"X_idx_sorted" was removed from the "DecisionTreeRegressor.fit" function in this sklearn version; 2) "from .mse_causal ..." reported "no module found" error in my environment, but "from mse_causal ..."  works well. 3) "X.treated.values.astype(int)" does not work in my environment. I guess it might be due to different pandas versions, and I am using pandas 1.5.3. 

Please see the comparisons between two branches, and let me know if there are any issues.

Yanfang